### PR TITLE
[Feature] Implement Read Command for Shell

### DIFF
--- a/Shell/CmdRead.cpp
+++ b/Shell/CmdRead.cpp
@@ -14,7 +14,7 @@ bool CommandRead::Call(const std::vector<std::string>& program) {
     return false;
   }
 
-  int lba = std::stoi(program[LBA_INDEX]);
+  unsigned int lba = std::stoi(program[LBA_INDEX]);
   if (IsInvalidLBA(lba)) {
     // ERROR VALUE: false
     return false;

--- a/Shell/CmdRead.cpp
+++ b/Shell/CmdRead.cpp
@@ -1,0 +1,30 @@
+#include "CmdRead.h"
+
+#include <iostream>
+
+CommandRead::CommandRead(SSDInterface* ssdInterface) : ssd(ssdInterface) {}
+
+int CommandRead::Call(std::vector<std::string> program) {
+  // program example:
+  // {"read", 1}
+
+  // precondition check
+  if (program.size() != 2) {
+    // ERROR VALUE: 1
+    return 1;
+  }
+
+  int lba = std::stoi(program[1]);
+  if (IsInvalidLBA(lba)) {
+    return 1;
+  }
+
+  std::string value = ssd->Read(lba);
+
+  std::cout << "[Read] LBA " << lba << " : " << value << "\n";
+
+  // SUCCESS VALUE: 0
+  return 0;
+}
+
+bool CommandRead::IsInvalidLBA(int lba) { return lba < 0 || lba >= 100; }

--- a/Shell/CmdRead.cpp
+++ b/Shell/CmdRead.cpp
@@ -4,7 +4,7 @@
 
 CommandRead::CommandRead(SSDInterface* ssdInterface) : ssd(ssdInterface) {}
 
-bool CommandRead::Call(std::vector<std::string> program) {
+bool CommandRead::Call(const std::vector<std::string>& program) {
   // program example:
   // {"read", 1}
 
@@ -28,4 +28,4 @@ bool CommandRead::Call(std::vector<std::string> program) {
   return true;
 }
 
-bool CommandRead::IsInvalidLBA(int lba) { return lba < MIN_LBA || lba > MAX_LBA; }
+bool CommandRead::IsInvalidLBA(unsigned int lba) { return lba > MAX_LBA; }

--- a/Shell/CmdRead.cpp
+++ b/Shell/CmdRead.cpp
@@ -4,27 +4,28 @@
 
 CommandRead::CommandRead(SSDInterface* ssdInterface) : ssd(ssdInterface) {}
 
-int CommandRead::Call(std::vector<std::string> program) {
+bool CommandRead::Call(std::vector<std::string> program) {
   // program example:
   // {"read", 1}
 
   // precondition check
-  if (program.size() != 2) {
-    // ERROR VALUE: 1
-    return 1;
+  if (program.size() != PROGRAM_SIZE) {
+    // ERROR VALUE: false
+    return false;
   }
 
-  int lba = std::stoi(program[1]);
+  int lba = std::stoi(program[LBA_INDEX]);
   if (IsInvalidLBA(lba)) {
-    return 1;
+    // ERROR VALUE: false
+    return false;
   }
 
   std::string value = ssd->Read(lba);
 
   std::cout << "[Read] LBA " << lba << " : " << value << "\n";
 
-  // SUCCESS VALUE: 0
-  return 0;
+  // SUCCESS VALUE: true
+  return true;
 }
 
-bool CommandRead::IsInvalidLBA(int lba) { return lba < 0 || lba >= 100; }
+bool CommandRead::IsInvalidLBA(int lba) { return lba < MIN_LBA || lba > MAX_LBA; }

--- a/Shell/CmdRead.h
+++ b/Shell/CmdRead.h
@@ -8,10 +8,14 @@
 class CommandRead {
  public:
   CommandRead(SSDInterface* ssdInterface);
-  int Call(std::vector<std::string> program);
+  bool Call(std::vector<std::string> program);
 
  private:
   bool IsInvalidLBA(int lba);
 
   SSDInterface* ssd;
+  const int LBA_INDEX = 1;
+  const int PROGRAM_SIZE = 2;
+  const int MIN_LBA = 0;
+  const int MAX_LBA = 99;
 };

--- a/Shell/CmdRead.h
+++ b/Shell/CmdRead.h
@@ -8,14 +8,13 @@
 class CommandRead {
  public:
   CommandRead(SSDInterface* ssdInterface);
-  bool Call(std::vector<std::string> program);
+  bool Call(const std::vector<std::string>& program);
 
  private:
-  bool IsInvalidLBA(int lba);
+  bool IsInvalidLBA(unsigned int lba);
 
   SSDInterface* ssd;
   const int LBA_INDEX = 1;
   const int PROGRAM_SIZE = 2;
-  const int MIN_LBA = 0;
-  const int MAX_LBA = 99;
+  const unsigned int MAX_LBA = 99;
 };

--- a/Shell/CmdRead.h
+++ b/Shell/CmdRead.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "SSDInterface.h"
+
+class CommandRead {
+ public:
+  CommandRead(SSDInterface* ssdInterface);
+  int Call(std::vector<std::string> program);
+
+ private:
+  bool IsInvalidLBA(int lba);
+
+  SSDInterface* ssd;
+};

--- a/Shell/MockSSD.h
+++ b/Shell/MockSSD.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <unordered_map>
 
 #include "SSDInterface.h"

--- a/Shell/SSDInterface.h
+++ b/Shell/SSDInterface.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <string>
 using std::string;
 

--- a/Shell/Shell.vcxproj
+++ b/Shell/Shell.vcxproj
@@ -206,10 +206,14 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CmdRead.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MockSSD.cpp" />
     <ClCompile Include="MockSSD.h" />
     <ClCompile Include="SSDInterface.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CmdRead.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Shell/Shell.vcxproj.filters
+++ b/Shell/Shell.vcxproj.filters
@@ -27,5 +27,13 @@
     <ClCompile Include="MockSSD.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="CmdRead.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CmdRead.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ShellUnitTest/ShellUnitTest.vcxproj
+++ b/ShellUnitTest/ShellUnitTest.vcxproj
@@ -208,7 +208,9 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\Shell\CmdRead.cpp" />
     <ClCompile Include="..\Shell\MockSSD.cpp" />
+    <ClCompile Include="gTestCmdRead.cpp" />
     <ClCompile Include="gTestMockSSD.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
@@ -217,6 +219,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Shell\MockSSD.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Shell\CmdRead.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ShellUnitTest/ShellUnitTest.vcxproj.filters
+++ b/ShellUnitTest/ShellUnitTest.vcxproj.filters
@@ -33,8 +33,19 @@
     <ClCompile Include="gTestMockSSD.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="gTestCmdRead.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Shell\CmdRead.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Shell\CmdRead.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ShellUnitTest/gTestCmdRead.cpp
+++ b/ShellUnitTest/gTestCmdRead.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <sstream>
+
+#include "../Shell/CmdRead.h"
+#include "../Shell/MockSSD.h"
+#include "gmock/gmock.h"
+
+TEST(CommandTest, ReadDefault) {
+  std::ostringstream oss;
+  auto oldCoutStreamBuf = std::cout.rdbuf();
+  std::cout.rdbuf(oss.rdbuf());
+
+  MockSSD ssd;
+  CommandRead cmd(&ssd);
+
+  EXPECT_EQ(0, cmd.Call({"read", "1"}));
+ 
+  std::cout.rdbuf(oldCoutStreamBuf);
+  std::string outputStr = oss.str();
+
+  EXPECT_EQ("[Read] LBA 1 : 0x00000000\n", outputStr);
+}
+
+TEST(CommandTest, ReadValue) {
+  std::ostringstream oss;
+  auto oldCoutStreamBuf = std::cout.rdbuf();
+  std::cout.rdbuf(oss.rdbuf());
+
+  MockSSD ssd;
+  CommandRead cmd(&ssd);
+  ssd.Write(1, "0x12345678");
+
+  EXPECT_EQ(0, cmd.Call({"read", "1"}));
+
+  std::cout.rdbuf(oldCoutStreamBuf);
+  std::string outputStr = oss.str();
+
+  EXPECT_EQ("[Read] LBA 1 : 0x12345678\n", outputStr);
+}
+
+TEST(CommandTest, ReadInvalidLBA) {
+  MockSSD ssd;
+  CommandRead cmd(&ssd);
+
+  EXPECT_EQ(1, cmd.Call({"read", "-1"}));
+}

--- a/ShellUnitTest/gTestCmdRead.cpp
+++ b/ShellUnitTest/gTestCmdRead.cpp
@@ -13,7 +13,7 @@ TEST(CommandTest, ReadDefault) {
   MockSSD ssd;
   CommandRead cmd(&ssd);
 
-  EXPECT_EQ(0, cmd.Call({"read", "1"}));
+  EXPECT_TRUE(cmd.Call({"read", "1"}));
  
   std::cout.rdbuf(oldCoutStreamBuf);
   std::string outputStr = oss.str();
@@ -30,7 +30,7 @@ TEST(CommandTest, ReadValue) {
   CommandRead cmd(&ssd);
   ssd.Write(1, "0x12345678");
 
-  EXPECT_EQ(0, cmd.Call({"read", "1"}));
+  EXPECT_TRUE(cmd.Call({"read", "1"}));
 
   std::cout.rdbuf(oldCoutStreamBuf);
   std::string outputStr = oss.str();
@@ -42,5 +42,5 @@ TEST(CommandTest, ReadInvalidLBA) {
   MockSSD ssd;
   CommandRead cmd(&ssd);
 
-  EXPECT_EQ(1, cmd.Call({"read", "-1"}));
+  EXPECT_FALSE(cmd.Call({"read", "-1"}));
 }


### PR DESCRIPTION
이 PR 은 Shell 프로젝트의 Read 커맨드를 구현하고 있습니다.

- Add CommandRead class for handling Shell Read command (`Shell/CmdRead.cpp`, `Shell/CmdRead.h`)
- Add corresponding gTests (`ShellUnitTest/gTestCmdRead.cpp`)
- 추가로, 헤더 파일을 두 번 이상 잘못 import하는 링커 문제가 있어 기존 헤더 파일들에 `#pragma once`를 추가