### PR TITLE
[feature] Add Cmd Exit Feature

### DIFF
--- a/Shell/CmdExit.cpp
+++ b/Shell/CmdExit.cpp
@@ -1,0 +1,14 @@
+#include "CmdExit.h"
+
+#include <iostream>
+
+bool CommandExit::Call(const std::vector<std::string>& tokens) {
+  if (tokens.size() != 1) {
+    std::cout << "INVALID COMMAND\n";
+    return false;
+  }
+
+  // 종료 의사만 반환. 실제 종료는 main 함수에서 진행
+  std::cout << "Shutting down\n";
+  return true;
+}

--- a/Shell/CmdExit.h
+++ b/Shell/CmdExit.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+#include <vector>
+
+class CommandExit {
+ public:
+  bool Call(const std::vector<std::string>& tokens);
+};

--- a/ShellUnitTest/gTestCmdExit.cpp
+++ b/ShellUnitTest/gTestCmdExit.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <sstream>
+
+#include "../Shell/CmdExit.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
+
+const std::string SHUTDOWN_MESSAGE = "Shutting down\n";
+const std::string INVALID_MESSAGE = "INVALID COMMAND\n";
+
+class CommandExitTest : public Test {
+ protected:
+  std::ostringstream oss;
+  std::streambuf* oldCout;
+
+  void SetUp() override {
+    oldCout = std::cout.rdbuf();
+    std::cout.rdbuf(oss.rdbuf());
+  }
+
+  void TearDown() override { std::cout.rdbuf(oldCout); }
+};
+
+TEST_F(CommandExitTest, ValidExitCommand) {
+  CommandExit cmd;
+  bool result = cmd.Call({"exit"});
+  std::string output = oss.str();
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(SHUTDOWN_MESSAGE, output);
+}
+
+TEST_F(CommandExitTest, InvalidExitWithExtraArg) {
+  CommandExit cmd;
+  bool result = cmd.Call({"exit", "now"});
+  std::string output = oss.str();
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(INVALID_MESSAGE, output);
+}
+
+TEST_F(CommandExitTest, InvalidExitWithNoArg) {
+  CommandExit cmd;
+  bool result = cmd.Call({});
+  std::string output = oss.str();
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(INVALID_MESSAGE, output);
+}


### PR DESCRIPTION
- exit 명령어 기능 추가
- CmdExit.h, CmdExit.cpp, gTestCommandExit.cpp 파일 구현
- exit 입력 시 "Shutting down" 메시지를 출력하고 true를 반환해 메인 루프 종료 유도
- 잘못된 인자 입력 시 "INVALID COMMAND" 출력 및 false 반환
- 기본 동작 테스트 작성 및 통과 완료