### PR TITLE
[Feature] Implement Erase Function for Shell MockSSD

### DIFF
--- a/Shell/MockSSD.cpp
+++ b/Shell/MockSSD.cpp
@@ -19,20 +19,11 @@ string MockSSD::Read(int lba) {
 }
 
 void MockSSD::Erase(int lba, int size) {
-  if (IsInvalidLBA(lba)) {
-    return;
-  }
-
-  // check validity of size
-  if (size < 0 || size > 10) {
+  if (IsInvalidLBA(lba) || IsInvalidErase(lba, size)) {
     return;
   }
 
   int lbaEnd = lba + size - 1;
-  if (lbaEnd >= 100) {
-    return;
-  }
-
   for (int lbaIndex = lba; lbaIndex <= lbaEnd; lbaIndex++) {
     cache.erase(lbaIndex);
   }
@@ -54,4 +45,18 @@ bool MockSSD::IsInvalidValue(const string& value) {
   }
 
   return false;
+}
+
+bool MockSSD::IsInvalidErase(int lba, int size) {
+  if (size < 0 || size > 10) {
+    return true;
+  }
+
+  if (size == 0) {
+    return false;
+  }
+
+  // assume lba is valid
+  int lbaEnd = lba + size - 1;
+  return lbaEnd >= 100;
 }

--- a/Shell/MockSSD.cpp
+++ b/Shell/MockSSD.cpp
@@ -18,6 +18,26 @@ string MockSSD::Read(int lba) {
   return "0x00000000";
 }
 
+void MockSSD::Erase(int lba, int size) {
+  if (IsInvalidLBA(lba)) {
+    return;
+  }
+
+  // check validity of size
+  if (size < 0 || size > 10) {
+    return;
+  }
+
+  int lbaEnd = lba + size - 1;
+  if (lbaEnd >= 100) {
+    return;
+  }
+
+  for (int lbaIndex = lba; lbaIndex <= lbaEnd; lbaIndex++) {
+    cache.erase(lbaIndex);
+  }
+}
+
 bool MockSSD::IsInvalidLBA(int lba) { return lba < 0 || lba >= 100; }
 
 bool MockSSD::IsInvalidValue(const string& value) {

--- a/Shell/MockSSD.h
+++ b/Shell/MockSSD.h
@@ -10,6 +10,7 @@ class MockSSD : public SSDInterface {
   void Erase(int lba, int size) override;
   bool IsInvalidLBA(int lba);
   bool IsInvalidValue(const string& value);
+  bool IsInvalidErase(int lba, int size);
 
  private:
   std::unordered_map<int, string> cache;

--- a/Shell/MockSSD.h
+++ b/Shell/MockSSD.h
@@ -7,6 +7,7 @@ class MockSSD : public SSDInterface {
  public:
   void Write(int lba, const string& value) override;
   string Read(int lba) override;
+  void Erase(int lba, int size) override;
   bool IsInvalidLBA(int lba);
   bool IsInvalidValue(const string& value);
 

--- a/Shell/RealSSD.cpp
+++ b/Shell/RealSSD.cpp
@@ -42,6 +42,10 @@ std::string RealSSD::Read(int lba) {
   return line;
 }
 
+void RealSSD::Erase(int lba, int size) {
+  throw std::runtime_error("RealSSD::Erase() Not implemented");
+}
+
 int RealSSD::execCommand(const std::string& cmd) {
   return std::system(cmd.c_str());
 }

--- a/Shell/RealSSD.h
+++ b/Shell/RealSSD.h
@@ -9,6 +9,7 @@ class RealSSD : public SSDInterface {
           const std::string& outputFile = "ssd_output.txt");
   void Write(int lba, const string& value) override;
   string Read(int lba) override;
+  void Erase(int lba, int size) override;
   bool IsInvalidLBA(int lba);
   bool IsInvalidValue(const string& value);
   virtual int execCommand(const std::string& cmd);

--- a/Shell/SSDInterface.h
+++ b/Shell/SSDInterface.h
@@ -6,4 +6,5 @@ class SSDInterface {
  public:
   virtual void Write(int lba, const string& value) = 0;
   virtual string Read(int lba) = 0;
+  virtual void Erase(int lba, int size) = 0;
 };

--- a/ShellUnitTest/gTestMockSSD.cpp
+++ b/ShellUnitTest/gTestMockSSD.cpp
@@ -182,3 +182,23 @@ TEST(MockSSDTest, Erase_InvalidRange) {
 
   EXPECT_EQ(ssd.Read(99), "0x10000000");
 }
+
+TEST(MockSSDTest, IsInvalidErase) {
+  MockSSD ssd;
+  EXPECT_FALSE(ssd.IsInvalidErase(0, 0));
+  EXPECT_FALSE(ssd.IsInvalidErase(0, 1));
+  EXPECT_FALSE(ssd.IsInvalidErase(0, 2));
+  EXPECT_FALSE(ssd.IsInvalidErase(0, 10));
+
+  EXPECT_FALSE(ssd.IsInvalidErase(50, 0));
+  EXPECT_FALSE(ssd.IsInvalidErase(50, 1));
+  EXPECT_FALSE(ssd.IsInvalidErase(50, 2));
+  EXPECT_FALSE(ssd.IsInvalidErase(50, 10));
+
+  EXPECT_FALSE(ssd.IsInvalidErase(95, 0));
+  EXPECT_FALSE(ssd.IsInvalidErase(95, 1));
+  EXPECT_FALSE(ssd.IsInvalidErase(95, 2));
+  EXPECT_TRUE(ssd.IsInvalidErase(95, 10));
+
+  EXPECT_TRUE(ssd.IsInvalidErase(95, -1));
+}

--- a/ShellUnitTest/gTestMockSSD.cpp
+++ b/ShellUnitTest/gTestMockSSD.cpp
@@ -91,3 +91,94 @@ TEST(MockSSDTest, IsInvalidValue_InvalidChars) {
   EXPECT_TRUE(ssd.IsInvalidValue("0x12#45678"));
   EXPECT_TRUE(ssd.IsInvalidValue("0x1234567!"));
 }
+
+TEST(MockSSDTest, Erase_Single) {
+  MockSSD ssd;
+  ssd.Write(10, "0x10000000");
+  ssd.Write(11, "0x11000000");
+  ssd.Write(12, "0x12000000");
+  ssd.Write(13, "0x13000000");
+  ssd.Write(14, "0x14000000");
+
+  ssd.Erase(9, 1);
+  ssd.Erase(12, 1);
+
+  EXPECT_EQ(ssd.Read(9), "0x00000000");
+  EXPECT_EQ(ssd.Read(10), "0x10000000");
+  EXPECT_EQ(ssd.Read(11), "0x11000000");
+  EXPECT_EQ(ssd.Read(12), "0x00000000");
+  EXPECT_EQ(ssd.Read(13), "0x13000000");
+  EXPECT_EQ(ssd.Read(14), "0x14000000");
+  EXPECT_EQ(ssd.Read(15), "0x00000000");
+}
+
+TEST(MockSSDTest, Erase_Double) {
+  MockSSD ssd;
+  ssd.Write(10, "0x10000000");
+  ssd.Write(11, "0x11000000");
+  ssd.Write(12, "0x12000000");
+  ssd.Write(13, "0x13000000");
+  ssd.Write(14, "0x14000000");
+
+  ssd.Erase(12, 2);
+
+  EXPECT_EQ(ssd.Read(9), "0x00000000");
+  EXPECT_EQ(ssd.Read(10), "0x10000000");
+  EXPECT_EQ(ssd.Read(11), "0x11000000");
+  EXPECT_EQ(ssd.Read(12), "0x00000000");
+  EXPECT_EQ(ssd.Read(13), "0x00000000");
+  EXPECT_EQ(ssd.Read(14), "0x14000000");
+  EXPECT_EQ(ssd.Read(15), "0x00000000");
+}
+
+TEST(MockSSDTest, Erase_All) {
+  MockSSD ssd;
+  ssd.Write(10, "0x10000000");
+  ssd.Write(11, "0x11000000");
+  ssd.Write(12, "0x12000000");
+  ssd.Write(13, "0x13000000");
+  ssd.Write(14, "0x14000000");
+
+  ssd.Erase(10, 5);
+
+  EXPECT_EQ(ssd.Read(10), "0x00000000");
+  EXPECT_EQ(ssd.Read(11), "0x00000000");
+  EXPECT_EQ(ssd.Read(12), "0x00000000");
+  EXPECT_EQ(ssd.Read(13), "0x00000000");
+  EXPECT_EQ(ssd.Read(14), "0x00000000");
+}
+
+TEST(MockSSDTest, Erase_Invalid) {
+  MockSSD ssd;
+  ssd.Write(10, "0x10000000");
+  ssd.Write(11, "0x11000000");
+  ssd.Write(12, "0x12000000");
+  ssd.Write(13, "0x13000000");
+  ssd.Write(14, "0x14000000");
+
+  ssd.Erase(8, 11);
+
+  EXPECT_EQ(ssd.Read(10), "0x10000000");
+  EXPECT_EQ(ssd.Read(11), "0x11000000");
+  EXPECT_EQ(ssd.Read(12), "0x12000000");
+  EXPECT_EQ(ssd.Read(13), "0x13000000");
+  EXPECT_EQ(ssd.Read(14), "0x14000000");
+}
+
+TEST(MockSSDTest, Erase_InvalidLBA) {
+  MockSSD ssd;
+  ssd.Write(0, "0x10000000");
+
+  ssd.Erase(-1, 2);
+
+  EXPECT_EQ(ssd.Read(0), "0x10000000");
+}
+
+TEST(MockSSDTest, Erase_InvalidRange) {
+  MockSSD ssd;
+  ssd.Write(99, "0x10000000");
+
+  ssd.Erase(99, 2);
+
+  EXPECT_EQ(ssd.Read(99), "0x10000000");
+}


### PR DESCRIPTION
이 PR은 Shell 프로젝트에서 사용하는 MockSSD (Mock Driver) 에 Erase 함수를 구현합니다.

Shell에서 제공하는 Erase 기능을 SSD 프로젝트의 구현체 없이 테스트하기 위해, 기존에 사용하고 있던 MockSSD에 Erase 함수를 추가한 것입니다.
Shell의 Erase 기능이 이 PR에 구현된 것은 아닙니다. Shell의 Erase 기능 PR이 너무 커지는 것을 막기 위해, 그 prerequisite으로 우선 MockSSD Erase만 따로 떼어서 이 PR로 만든 것입니다.

- Erase function in MockSSD (`Shell/MockSSD.cpp`, `Shell/MockSSD.h`)
- Cooresponding gTests (`ShellUnitTest/gTestMockSSD.cpp`)