### PR TITLE
[Feature] Add Flush Command for SSDInterface

### DIFF
--- a/Shell/MockSSD.cpp
+++ b/Shell/MockSSD.cpp
@@ -29,6 +29,11 @@ void MockSSD::Erase(int lba, int size) {
   }
 }
 
+void MockSSD::Flush() {
+  // No-op: MockSSD applies writes directly to its cache,
+  // so there is no buffered data that needs flushing.
+}
+
 bool MockSSD::IsInvalidLBA(int lba) { return lba < 0 || lba >= 100; }
 
 bool MockSSD::IsInvalidValue(const string& value) {

--- a/Shell/MockSSD.h
+++ b/Shell/MockSSD.h
@@ -8,6 +8,8 @@ class MockSSD : public SSDInterface {
   void Write(int lba, const string& value) override;
   string Read(int lba) override;
   void Erase(int lba, int size) override;
+  void Flush() override;
+
   bool IsInvalidLBA(int lba);
   bool IsInvalidValue(const string& value);
   bool IsInvalidErase(int lba, int size);

--- a/Shell/RealSSD.cpp
+++ b/Shell/RealSSD.cpp
@@ -46,6 +46,12 @@ void RealSSD::Erase(int lba, int size) {
   throw std::runtime_error("RealSSD::Erase() Not implemented");
 }
 
+void RealSSD::Flush() {
+  std::ostringstream cmd;
+  cmd << ssdExe << " F";
+  execCommand(cmd.str());
+}
+
 int RealSSD::execCommand(const std::string& cmd) {
   return std::system(cmd.c_str());
 }

--- a/Shell/RealSSD.h
+++ b/Shell/RealSSD.h
@@ -10,6 +10,8 @@ class RealSSD : public SSDInterface {
   void Write(int lba, const string& value) override;
   string Read(int lba) override;
   void Erase(int lba, int size) override;
+  void Flush() override;
+
   bool IsInvalidLBA(int lba);
   bool IsInvalidValue(const string& value);
   virtual int execCommand(const std::string& cmd);

--- a/Shell/SSDInterface.h
+++ b/Shell/SSDInterface.h
@@ -7,4 +7,5 @@ class SSDInterface {
   virtual void Write(int lba, const string& value) = 0;
   virtual string Read(int lba) = 0;
   virtual void Erase(int lba, int size) = 0;
+  virtual void Flush() = 0;
 };


### PR DESCRIPTION
변경사항
- SSDInterface에 순수 가상 함수 virtual void Flush() 추가
- RealSSD에 Flush() 구현 
- MockSSD에 Flush() 추가 (no-op으로 즉시 리턴)

비고
- 3일차(3rd day)부터는 TDD 개발이 필수가 아니므로, 이번 PR에는 테스트 코드를 포함하지 않습니다.
- Test Shell에 flush 명령어 매핑하는 것은 다음 PR에서 진행 예정입니다.

빌드 테스트
- 본 코드 추가가 전체 빌드 테스트에 문제 없는 것 확인했습니다.