### PR TITLE
[Feature] Implement Erase Function for Shell

### DIFF
--- a/Shell/CmdErase.cpp
+++ b/Shell/CmdErase.cpp
@@ -31,6 +31,8 @@ bool CommandErase::Call(const std::vector<std::string>& program) {
     return false;
   }
 
+  ssd->Erase(lba, size);
+
   // SUCCESS
   std::cout << "[Erase] Done\n";
   return true;

--- a/Shell/CmdErase.cpp
+++ b/Shell/CmdErase.cpp
@@ -1,0 +1,39 @@
+#include "CmdErase.h"
+
+#include <iostream>
+
+CommandErase::CommandErase(SSDInterface* ssdInterface) : ssd(ssdInterface) {}
+
+bool CommandErase::Call(const std::vector<std::string>& program) {
+  // program example:
+  // {"erase", "5", "20"}
+  // {"erase", "60", "-200"}
+  // {"erase", "99", "0"}
+
+  // precondition check
+  if (program.size() != PROGRAM_SIZE) {
+    // ERROR
+    return false;
+  }
+
+  unsigned int lba;
+  int size;
+  try {
+    lba = std::stoi(program[LBA_INDEX]);
+    size = std::stoi(program[SIZE_INDEX]);
+  } catch (...) {
+    // ERROR
+    return false;
+  }
+
+  if (IsInvalidLBA(lba)) {
+    // ERROR
+    return false;
+  }
+
+  // SUCCESS
+  std::cout << "[Erase] Done\n";
+  return true;
+}
+
+bool CommandErase::IsInvalidLBA(unsigned int lba) { return lba > MAX_LBA; }

--- a/Shell/CmdErase.cpp
+++ b/Shell/CmdErase.cpp
@@ -31,7 +31,13 @@ bool CommandErase::Call(const std::vector<std::string>& program) {
     return false;
   }
 
-  ssd->Erase(lba, size);
+  if (size >= 0) {
+    ssd->Erase(lba, size);
+  } else {
+    int lbaStart = lba + size + 1;
+    int sizeForward = -size;
+    ssd->Erase(lbaStart, sizeForward);
+  }
 
   // SUCCESS
   std::cout << "[Erase] Done\n";

--- a/Shell/CmdErase.cpp
+++ b/Shell/CmdErase.cpp
@@ -31,13 +31,11 @@ bool CommandErase::Call(const std::vector<std::string>& program) {
     return false;
   }
 
-  if (size >= 0) {
-    ssd->Erase(lba, size);
-  } else {
-    int lbaStart = lba + size + 1;
-    int sizeForward = -size;
-    ssd->Erase(lbaStart, sizeForward);
-  }
+  // in case size < 0, convert lba & size to go forwards (lba 0 --> 99)
+  unsigned int lbaForward = GetForwardLBA(lba, size);
+  int sizeForward = GetForwardSize(size);
+
+  ssd->Erase(lbaForward, sizeForward);
 
   // SUCCESS
   std::cout << "[Erase] Done\n";
@@ -45,3 +43,19 @@ bool CommandErase::Call(const std::vector<std::string>& program) {
 }
 
 bool CommandErase::IsInvalidLBA(unsigned int lba) { return lba > MAX_LBA; }
+
+unsigned int CommandErase::GetForwardLBA(unsigned int lba, int size) {
+  if (size < 0) {
+    return lba + size + 1;
+  } else {
+    return lba;
+  }
+}
+
+int CommandErase::GetForwardSize(int size) {
+  if (size < 0) {
+    return -size;
+  } else {
+    return size;
+  }
+}

--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -12,6 +12,8 @@ class CommandErase {
 
  private:
   bool IsInvalidLBA(unsigned int lba);
+  unsigned int GetForwardLBA(unsigned int lba, int size);
+  int GetForwardSize(int size);
 
   SSDInterface* ssd;
   const int LBA_INDEX = 1;

--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -14,7 +14,13 @@ class CommandErase {
   bool IsInvalidLBA(unsigned int lba);
   unsigned int GetForwardLBA(unsigned int lba, int size);
   int GetForwardSize(unsigned int lba, int size);
+
+  // erase algorithm related functions
   void ExecuteErase(unsigned int lba, int size);
+  bool IsValidErase(unsigned int lbaCurr, int remainingSize);
+  int GetActualEraseSize(unsigned int lbaCurr, int cappedSize);
+  void updateLbaAndSize(unsigned int& lbaCurr, int& remainingSize,
+                        int actualSize);
 
   SSDInterface* ssd;
   const int LBA_INDEX = 1;

--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -14,10 +14,12 @@ class CommandErase {
   bool IsInvalidLBA(unsigned int lba);
   unsigned int GetForwardLBA(unsigned int lba, int size);
   int GetForwardSize(int size);
+  void ExecuteErase(unsigned int lba, int size);
 
   SSDInterface* ssd;
   const int LBA_INDEX = 1;
   const int SIZE_INDEX = 2;
   const int PROGRAM_SIZE = 3;
   const unsigned int MAX_LBA = 99;
+  const int SSD_ERASE_MAX_SIZE = 10;
 };

--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -13,7 +13,7 @@ class CommandErase {
  private:
   bool IsInvalidLBA(unsigned int lba);
   unsigned int GetForwardLBA(unsigned int lba, int size);
-  int GetForwardSize(int size);
+  int GetForwardSize(unsigned int lba, int size);
   void ExecuteErase(unsigned int lba, int size);
 
   SSDInterface* ssd;

--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "SSDInterface.h"
+
+class CommandErase {
+ public:
+  CommandErase(SSDInterface* ssdInterface);
+  bool Call(const std::vector<std::string>& program);
+
+ private:
+  bool IsInvalidLBA(unsigned int lba);
+
+  SSDInterface* ssd;
+  const int LBA_INDEX = 1;
+  const int SIZE_INDEX = 2;
+  const int PROGRAM_SIZE = 3;
+  const unsigned int MAX_LBA = 99;
+};

--- a/Shell/Shell.vcxproj
+++ b/Shell/Shell.vcxproj
@@ -212,6 +212,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="CmdExit.cpp" />
+    <ClCompile Include="CmdErase.cpp" />
     <ClCompile Include="CmdFullRead.cpp" />
     <ClCompile Include="CmdFullWrite.cpp" />
     <ClCompile Include="CmdHelp.cpp" />
@@ -228,6 +229,7 @@
   <ItemGroup>
     <ClInclude Include="CmdExit.h" />
     <ClInclude Include="CmdHelp.h" />
+    <ClInclude Include="CmdErase.h" />
     <ClInclude Include="IParam.h" />
     <ClInclude Include="CmdFullRead.h" />
     <ClInclude Include="CmdFullWrite.h" />

--- a/Shell/Shell.vcxproj.filters
+++ b/Shell/Shell.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClCompile Include="CmdExit.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="CmdErase.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CmdFullRead.h">
@@ -63,6 +66,9 @@
     <ClInclude Include="Parser.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="IParam.h">
+      <Filter>소스 파일</Filter>
+    </ClInclude>
     <ClInclude Include="RealSSD.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
@@ -73,6 +79,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="CmdHelp.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="CmdErase.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ShellUnitTest/ShellUnitTest.vcxproj
+++ b/ShellUnitTest/ShellUnitTest.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="..\Shell\CmdWrite.cpp" />
     <ClCompile Include="..\Shell\MockSSD.cpp" />
     <ClCompile Include="gTestCmdExit.cpp" />
+    <ClCompile Include="gTestCmdErase.cpp" />
     <ClCompile Include="gTestCmdFullRead.cpp" />
     <ClCompile Include="gTestCmdRead.cpp" />
     <ClCompile Include="gTestCommandHelp.cpp" />

--- a/ShellUnitTest/ShellUnitTest.vcxproj.filters
+++ b/ShellUnitTest/ShellUnitTest.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="gTestCommandHelp.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="gTestCmdErase.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -133,3 +133,15 @@ TEST_F(EraseTestFixture, EraseFullOverRange) {
     EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
   }
 }
+
+TEST_F(EraseTestFixture, EraseFullOverRangeBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  cmd.Call({"erase", "99", "-300"});
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -77,3 +77,33 @@ TEST_F(EraseTestFixture, EraseSingleCmdBackwards) {
   EXPECT_EQ(ssd.Read(3), DEFAULT_VALUE);
   EXPECT_EQ(ssd.Read(4), DEFAULT_VALUE);
 }
+
+TEST_F(EraseTestFixture, EraseMultiCmd) {
+  ssd.Write(0, "0x10000000");
+  ssd.Write(1, "0x11000000");
+  ssd.Write(2, "0x12000000");
+  ssd.Write(3, "0x13000000");
+  ssd.Write(4, "0x14000000");
+  ssd.Write(5, "0x15000000");
+  ssd.Write(6, "0x16000000");
+  ssd.Write(7, "0x17000000");
+  ssd.Write(8, "0x18000000");
+  ssd.Write(9, "0x19000000");
+  ssd.Write(10, "0x20000000");
+  ssd.Write(11, "0x21000000");
+  ssd.Write(12, "0x22000000");
+  ssd.Write(13, "0x23000000");
+  ssd.Write(14, "0x24000000");
+
+  EXPECT_TRUE(cmd.Call({"erase", "0", "11"}));
+  CheckSuccess();
+
+  for (int i = 0; i < 11; i++) {
+    EXPECT_EQ(ssd.Read(i), DEFAULT_VALUE);
+  }
+
+  EXPECT_EQ(ssd.Read(11), "0x21000000");
+  EXPECT_EQ(ssd.Read(12), "0x22000000");
+  EXPECT_EQ(ssd.Read(13), "0x23000000");
+  EXPECT_EQ(ssd.Read(14), "0x24000000");
+}

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <sstream>
+
+#include "../Shell/CmdErase.h"
+#include "../Shell/MockSSD.h"
+#include "gmock/gmock.h"
+
+using namespace testing;
+
+class EraseTestFixture : public Test {
+ public:
+  void SetUp() override {
+    oldCoutStreamBuf = std::cout.rdbuf();
+    std::cout.rdbuf(oss.rdbuf());
+  }
+
+  void TearDown() override { std::cout.rdbuf(oldCoutStreamBuf); }
+
+  std::string GetCoutStr() { return oss.str(); }
+
+  bool CheckSuccess() { return GetCoutStr() == "[Erase] Done\n"; }
+
+  bool ClearCoutStr() { oss.clear(); }
+
+  std::ostringstream oss;
+  std::streambuf* oldCoutStreamBuf;
+
+  MockSSD ssd;
+  CommandErase cmd{&ssd};
+};
+
+TEST_F(EraseTestFixture, EraseInvalidLBA) {
+  EXPECT_FALSE(cmd.Call({"erase", "-1", "20"}));
+  CheckSuccess();
+}
+
+TEST_F(EraseTestFixture, EraseZero) {
+  EXPECT_TRUE(cmd.Call({"erase", "0", "0"}));
+  CheckSuccess();
+  EXPECT_TRUE(cmd.Call({"erase", "50", "0"}));
+  CheckSuccess();
+  EXPECT_TRUE(cmd.Call({"erase", "99", "0"}));
+  CheckSuccess();
+}

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -27,6 +27,7 @@ class EraseTestFixture : public Test {
 
   MockSSD ssd;
   CommandErase cmd{&ssd};
+  const char* DEFAULT_VALUE = "0x00000000";
 };
 
 TEST_F(EraseTestFixture, EraseInvalidLBA) {
@@ -41,4 +42,21 @@ TEST_F(EraseTestFixture, EraseZero) {
   CheckSuccess();
   EXPECT_TRUE(cmd.Call({"erase", "99", "0"}));
   CheckSuccess();
+}
+
+TEST_F(EraseTestFixture, EraseSingleCmd) {
+  ssd.Write(0, "0x10000000");
+  ssd.Write(1, "0x11000000");
+  ssd.Write(2, "0x12000000");
+  ssd.Write(3, "0x13000000");
+  ssd.Write(4, "0x14000000");
+
+  EXPECT_TRUE(cmd.Call({"erase", "0", "5"}));
+  CheckSuccess();
+
+  EXPECT_EQ(ssd.Read(0), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(1), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(2), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(3), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(4), DEFAULT_VALUE);
 }

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -98,6 +98,28 @@ TEST_F(EraseTestFixture, EraseMultiCmd) {
   }
 }
 
+TEST_F(EraseTestFixture, EraseMultiCmdBackwards) {
+  for (unsigned int lba = 0; lba < 30; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase", "20", "-15"}));
+  CheckSuccess();
+
+  for (unsigned int lba = 0; lba < 6; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 6; lba < 21; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+  for (unsigned int lba = 21; lba < 30; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 30; lba < 31; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
 TEST_F(EraseTestFixture, EraseFull) {
   for (unsigned int lba = 0; lba < 100; lba++) {
     WritePresetValue(lba);
@@ -140,6 +162,32 @@ TEST_F(EraseTestFixture, EraseFullOverRangeBackwards) {
   }
 
   cmd.Call({"erase", "99", "-300"});
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseTestFixture, EraseMultiCmdFull) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase", "0", "300"}));
+  CheckSuccess();
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseTestFixture, EraseMultiCmdFullBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase", "99", "-300"}));
+  CheckSuccess();
 
   for (unsigned int lba = 0; lba < 100; lba++) {
     EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));

--- a/ShellUnitTest/gTestCmdErase.cpp
+++ b/ShellUnitTest/gTestCmdErase.cpp
@@ -60,3 +60,20 @@ TEST_F(EraseTestFixture, EraseSingleCmd) {
   EXPECT_EQ(ssd.Read(3), DEFAULT_VALUE);
   EXPECT_EQ(ssd.Read(4), DEFAULT_VALUE);
 }
+
+TEST_F(EraseTestFixture, EraseSingleCmdBackwards) {
+  ssd.Write(0, "0x10000000");
+  ssd.Write(1, "0x11000000");
+  ssd.Write(2, "0x12000000");
+  ssd.Write(3, "0x13000000");
+  ssd.Write(4, "0x14000000");
+
+  EXPECT_TRUE(cmd.Call({"erase", "4", "-5"}));
+  CheckSuccess();
+
+  EXPECT_EQ(ssd.Read(0), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(1), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(2), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(3), DEFAULT_VALUE);
+  EXPECT_EQ(ssd.Read(4), DEFAULT_VALUE);
+}


### PR DESCRIPTION
이 PR은 Shell 프로젝트의 Erase 커맨드를 구현합니다.

- Implement CommandErase class (`Shell/CmdErase.cpp`, `Shell/CmdErase.h`)
- Corresponding gTests (`ShellUnitTest/gTestCmdErase.cpp.cpp`)
  - 왠만한 corner case까지 다 다루고 있습니다. (음수 size, 100보다 큰 size, 등등...)

**NOTE**
- Erase_range 커맨드는 별도입니다. 추후 PR에서 구현할 예정입니다.
- Parser에는 "erase" 커맨드를 아직 파지 않았습니다