### PR TITLE
[Feature] Implement EraseRange Function for Shell

### DIFF
--- a/Shell/CmdErase.h
+++ b/Shell/CmdErase.h
@@ -11,7 +11,6 @@ class CommandErase {
   bool Call(const std::vector<std::string>& program);
 
  private:
-  bool IsInvalidLBA(unsigned int lba);
   unsigned int GetForwardLBA(unsigned int lba, int size);
   int GetForwardSize(unsigned int lba, int size);
 
@@ -22,10 +21,14 @@ class CommandErase {
   void updateLbaAndSize(unsigned int& lbaCurr, int& remainingSize,
                         int actualSize);
 
-  SSDInterface* ssd;
   const int LBA_INDEX = 1;
   const int SIZE_INDEX = 2;
   const int PROGRAM_SIZE = 3;
-  const unsigned int MAX_LBA = 99;
   const int SSD_ERASE_MAX_SIZE = 10;
+
+ protected:
+  bool IsInvalidLBA(unsigned int lba);
+
+  SSDInterface* ssd;
+  const unsigned int MAX_LBA = 99;
 };

--- a/Shell/CmdEraseRange.cpp
+++ b/Shell/CmdEraseRange.cpp
@@ -2,8 +2,10 @@
 
 #include <iostream>
 
+#include "logger.h"
+
 CommandEraseRange::CommandEraseRange(SSDInterface* ssdInterface)
-    : ssd(ssdInterface) {}
+    : CommandErase(ssdInterface) {}
 
 bool CommandEraseRange::Call(const std::vector<std::string>& program) {
   // program example:
@@ -32,24 +34,13 @@ bool CommandEraseRange::Call(const std::vector<std::string>& program) {
     return false;
   }
 
-  if (lbaEnd < lbaStart) {
-    unsigned int tmp = lbaEnd;
-    lbaEnd = lbaStart;
-    lbaStart = tmp;
-  }
+  int size =
+      (lbaStart <= lbaEnd) ? lbaEnd - lbaStart + 1 : lbaEnd - lbaStart - 1;
 
-  while (lbaStart <= lbaEnd) {
-    int size = lbaEnd - lbaStart + 1;
-    int actualSize = (size > 10) ? 10 : size;
 
-    ssd->Erase(lbaStart, actualSize);
+  std::vector<std::string> eraseProgram = {"erase",
+                                           std::to_string(lbaStart),
+                                           std::to_string(size)};
 
-    lbaStart += actualSize;
-  }
-
-  // SUCCESS
-  std::cout << "[Eraserange] Done\n";
-  return true;
+  return CommandErase::Call(eraseProgram);
 }
-
-bool CommandEraseRange::IsInvalidLBA(unsigned int lba) { return lba > MAX_LBA; }

--- a/Shell/CmdEraseRange.cpp
+++ b/Shell/CmdEraseRange.cpp
@@ -1,0 +1,55 @@
+#include "CmdEraseRange.h"
+
+#include <iostream>
+
+CommandEraseRange::CommandEraseRange(SSDInterface* ssdInterface)
+    : ssd(ssdInterface) {}
+
+bool CommandEraseRange::Call(const std::vector<std::string>& program) {
+  // program example:
+  // {"erase_range", "5", "20"}
+  // {"erase_range", "60", "40"}
+  // {"erase_range", "0", "99"}
+
+  // precondition check
+  if (program.size() != PROGRAM_SIZE) {
+    // ERROR
+    return false;
+  }
+
+  unsigned int lbaStart;
+  unsigned int lbaEnd;
+  try {
+    lbaStart = std::stoi(program[LBA_START_INDEX]);
+    lbaEnd = std::stoi(program[LBA_END_INDEX]);
+  } catch (...) {
+    // ERROR
+    return false;
+  }
+
+  if (IsInvalidLBA(lbaStart) || IsInvalidLBA(lbaEnd)) {
+    // ERROR
+    return false;
+  }
+
+  if (lbaEnd < lbaStart) {
+    unsigned int tmp = lbaEnd;
+    lbaEnd = lbaStart;
+    lbaStart = tmp;
+  }
+
+  while (lbaStart <= lbaEnd) {
+    int size = lbaEnd - lbaStart + 1;
+    int actualSize = (size > 10) ? 10 : size;
+
+    ssd->Erase(lbaStart, actualSize);
+
+    lbaStart += actualSize;
+  }
+
+  // SUCCESS
+  std::cout << "[Eraserange] Done\n";
+  return true;
+}
+
+bool CommandEraseRange::IsInvalidLBA(unsigned int lba) { return lba > MAX_LBA; }

--- a/Shell/CmdEraseRange.h
+++ b/Shell/CmdEraseRange.h
@@ -3,19 +3,16 @@
 #include <string>
 #include <vector>
 
+#include "CmdErase.h"
 #include "SSDInterface.h"
 
-class CommandEraseRange {
+class CommandEraseRange : public CommandErase {
  public:
   CommandEraseRange(SSDInterface* ssdInterface);
   bool Call(const std::vector<std::string>& program);
 
  private:
-  bool IsInvalidLBA(unsigned int lba);
-
-  SSDInterface* ssd;
   const int LBA_START_INDEX = 1;
   const int LBA_END_INDEX = 2;
   const int PROGRAM_SIZE = 3;
-  const unsigned int MAX_LBA = 99;
 };

--- a/Shell/CmdEraseRange.h
+++ b/Shell/CmdEraseRange.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "SSDInterface.h"
+
+class CommandEraseRange {
+ public:
+  CommandEraseRange(SSDInterface* ssdInterface);
+  bool Call(const std::vector<std::string>& program);
+
+ private:
+  bool IsInvalidLBA(unsigned int lba);
+
+  SSDInterface* ssd;
+  const int LBA_START_INDEX = 1;
+  const int LBA_END_INDEX = 2;
+  const int PROGRAM_SIZE = 3;
+  const unsigned int MAX_LBA = 99;
+};

--- a/Shell/Shell.vcxproj
+++ b/Shell/Shell.vcxproj
@@ -212,6 +212,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CmdEraseRange.cpp" />
     <ClCompile Include="CmdExit.cpp" />
     <ClCompile Include="CmdFlush.cpp" />
     <ClCompile Include="CmdErase.cpp" />
@@ -231,6 +232,7 @@
     <ClCompile Include="TestShell.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CmdEraseRange.h" />
     <ClInclude Include="ILogFileSystem.h" />
     <ClInclude Include="ILogger.h" />
     <ClInclude Include="CmdExit.h" />

--- a/Shell/Shell.vcxproj.filters
+++ b/Shell/Shell.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="CmdErase.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="CmdEraseRange.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CmdFullRead.h">
@@ -115,6 +118,9 @@
     </ClInclude>
     <ClInclude Include="ILogFileSystem.h">
       <Filter>소스 파일\Logger</Filter>
+    </ClInclude>
+    <ClInclude Include="CmdEraseRange.h">
+      <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/ShellUnitTest/ShellUnitTest.vcxproj
+++ b/ShellUnitTest/ShellUnitTest.vcxproj
@@ -217,6 +217,7 @@
   <ItemGroup>
     <ClCompile Include="..\Shell\CmdWrite.cpp" />
     <ClCompile Include="..\Shell\MockSSD.cpp" />
+    <ClCompile Include="gTestCmdEraseRange.cpp" />
     <ClCompile Include="gTestCmdExit.cpp" />
     <ClCompile Include="gTestCmdFlush.cpp" />
     <ClCompile Include="gTestCmdErase.cpp" />

--- a/ShellUnitTest/ShellUnitTest.vcxproj.filters
+++ b/ShellUnitTest/ShellUnitTest.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="gTestCmdErase.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="gTestCmdEraseRange.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ShellUnitTest/gTestCmdEraseRange.cpp
+++ b/ShellUnitTest/gTestCmdEraseRange.cpp
@@ -13,6 +13,8 @@ class EraseRangeTestFixture : public Test {
   void SetUp() override {
     oldCoutStreamBuf = std::cout.rdbuf();
     std::cout.rdbuf(oss.rdbuf());
+
+    WritePresetValueAll();
   }
 
   void TearDown() override { std::cout.rdbuf(oldCoutStreamBuf); }
@@ -25,13 +27,28 @@ class EraseRangeTestFixture : public Test {
 
   std::string GetPresetValue(unsigned int lba) {
     std::stringstream ss;
-    ss << "0x" << std::setw(8) << std::setfill('0') << std::hex << lba;
+    // we print lba + 1, to avoid setting 0x00000000 for lba = 0
+    ss << "0x" << std::setw(8) << std::setfill('0') << std::hex << (lba + 1);
     return ss.str();
   }
 
   void WritePresetValue(unsigned int lba) {
     auto value = GetPresetValue(lba);
     ssd.Write(lba, value);
+  }
+
+  void WritePresetValueAll() {
+    for (unsigned int lba = 0; lba < 100; lba++) {
+      WritePresetValue(lba);
+    }
+  }
+
+  void CheckPreset(unsigned int lba) {
+    EXPECT_EQ(ssd.Read(lba), GetPresetValue(lba));
+  }
+
+  void CheckErased(unsigned int lba) {
+    EXPECT_EQ(ssd.Read(lba), DEFAULT_VALUE);
   }
 
   std::ostringstream oss;
@@ -49,138 +66,110 @@ TEST_F(EraseRangeTestFixture, InvalidLBA) {
   EXPECT_FALSE(cmd.Call({"erase_range", "100", "-1"}));
   EXPECT_FALSE(cmd.Call({"erase_range", "99", "100"}));
   EXPECT_FALSE(cmd.Call({"erase_range", "100", "99"}));
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    CheckPreset(lba);
+  }
 }
 
 TEST_F(EraseRangeTestFixture, SingleCmd) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "50", "54"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 50; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 50; lba < 55; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
   for (unsigned int lba = 55; lba < 100; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, SingleCmdBackwards) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "54", "50"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 50; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 50; lba < 55; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
   for (unsigned int lba = 55; lba < 100; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, MultiCmd) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "45", "70"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 45; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 45; lba < 71; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
   for (unsigned int lba = 71; lba < 100; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, MultiCmdBackwards) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "70", "45"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 45; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 45; lba < 71; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
   for (unsigned int lba = 71; lba < 100; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, FullErase) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "0", "99"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 100; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, FullEraseBackwards) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "99", "0"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 100; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, EdgeCase) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "70", "99"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 70; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 70; lba < 100; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
 }
 
 TEST_F(EraseRangeTestFixture, EdgeCaseBackwards) {
-  for (unsigned int lba = 0; lba < 100; lba++) {
-    WritePresetValue(lba);
-  }
-
   EXPECT_TRUE(cmd.Call({"erase_range", "99", "70"}));
   EXPECT_TRUE(CheckSuccess());
 
   for (unsigned int lba = 0; lba < 70; lba++) {
-    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+    CheckPreset(lba);
   }
   for (unsigned int lba = 70; lba < 100; lba++) {
-    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+    CheckErased(lba);
   }
 }

--- a/ShellUnitTest/gTestCmdEraseRange.cpp
+++ b/ShellUnitTest/gTestCmdEraseRange.cpp
@@ -21,7 +21,7 @@ class EraseRangeTestFixture : public Test {
 
   std::string GetCoutStr() { return oss.str(); }
 
-  bool CheckSuccess() { return GetCoutStr() == "[Eraserange] Done\n"; }
+  bool CheckSuccess() { return GetCoutStr() == "[Erase] Done\n"; }
 
   void ClearCoutStr() { oss.str(""); }
 

--- a/ShellUnitTest/gTestCmdEraseRange.cpp
+++ b/ShellUnitTest/gTestCmdEraseRange.cpp
@@ -1,0 +1,186 @@
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "../Shell/CmdEraseRange.h"
+#include "../Shell/MockSSD.h"
+#include "gmock/gmock.h"
+
+using namespace testing;
+
+class EraseRangeTestFixture : public Test {
+ public:
+  void SetUp() override {
+    oldCoutStreamBuf = std::cout.rdbuf();
+    std::cout.rdbuf(oss.rdbuf());
+  }
+
+  void TearDown() override { std::cout.rdbuf(oldCoutStreamBuf); }
+
+  std::string GetCoutStr() { return oss.str(); }
+
+  bool CheckSuccess() { return GetCoutStr() == "[Eraserange] Done\n"; }
+
+  void ClearCoutStr() { oss.str(""); }
+
+  std::string GetPresetValue(unsigned int lba) {
+    std::stringstream ss;
+    ss << "0x" << std::setw(8) << std::setfill('0') << std::hex << lba;
+    return ss.str();
+  }
+
+  void WritePresetValue(unsigned int lba) {
+    auto value = GetPresetValue(lba);
+    ssd.Write(lba, value);
+  }
+
+  std::ostringstream oss;
+  std::streambuf* oldCoutStreamBuf;
+
+  MockSSD ssd;
+  CommandEraseRange cmd{&ssd};
+  const char* DEFAULT_VALUE = "0x00000000";
+};
+
+TEST_F(EraseRangeTestFixture, InvalidLBA) {
+  EXPECT_FALSE(cmd.Call({"erase_range", "-1", "0"}));
+  EXPECT_FALSE(cmd.Call({"erase_range", "0", "-1"}));
+  EXPECT_FALSE(cmd.Call({"erase_range", "-1", "100"}));
+  EXPECT_FALSE(cmd.Call({"erase_range", "100", "-1"}));
+  EXPECT_FALSE(cmd.Call({"erase_range", "99", "100"}));
+  EXPECT_FALSE(cmd.Call({"erase_range", "100", "99"}));
+}
+
+TEST_F(EraseRangeTestFixture, SingleCmd) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "50", "54"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 50; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 50; lba < 55; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+  for (unsigned int lba = 55; lba < 100; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, SingleCmdBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "54", "50"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 50; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 50; lba < 55; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+  for (unsigned int lba = 55; lba < 100; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, MultiCmd) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "45", "70"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 45; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 45; lba < 71; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+  for (unsigned int lba = 71; lba < 100; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, MultiCmdBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "70", "45"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 45; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 45; lba < 71; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+  for (unsigned int lba = 71; lba < 100; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, FullErase) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "0", "99"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, FullEraseBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "99", "0"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, EdgeCase) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "70", "99"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 70; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 70; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}
+
+TEST_F(EraseRangeTestFixture, EdgeCaseBackwards) {
+  for (unsigned int lba = 0; lba < 100; lba++) {
+    WritePresetValue(lba);
+  }
+
+  EXPECT_TRUE(cmd.Call({"erase_range", "99", "70"}));
+  EXPECT_TRUE(CheckSuccess());
+
+  for (unsigned int lba = 0; lba < 70; lba++) {
+    EXPECT_EQ(GetPresetValue(lba), ssd.Read(lba));
+  }
+  for (unsigned int lba = 70; lba < 100; lba++) {
+    EXPECT_EQ(DEFAULT_VALUE, ssd.Read(lba));
+  }
+}


### PR DESCRIPTION
이 PR은 Shell 프로젝트의 Erase 커맨드를 구현합니다.

* 새로 추가된 CommandEraseRange 클래스는 기존 CommandErase와 많은 로직이 겹쳐, 코드 중복을 줄이기 위해 CommandErase클래스를 inherit 하도록 설계하였습니다.
* Corresponding gTests (ShellUnitTest/gTestCmdEraseRange.cpp)

**NOTE**
* Parser에는 "erase_range" 커맨드를 파싱하는 로직을 아직 삽입하지 않았습니다. 추후 PR에서 구현 예정입니다.