### PR TITLE
[Feature] Integration Shell Erase/EraseRange commands with SSD

### DIFF
--- a/Shell/IParam.h
+++ b/Shell/IParam.h
@@ -10,6 +10,7 @@ enum TestShellCMD {
   eFullread,
   eFlushCmd,
   eEraseCmd,
+  eEraseRangeCmd,
   eScriptCmd,
   eInvalidCmd
 };
@@ -47,6 +48,14 @@ class EraseParam : public IParam {
   EraseParam(TestShellCMD cmd, string lba, string size) : IParam(cmd), lba(lba), size(size) {}
   string lba;
   string size;
+};
+
+class EraseRangeParam : public IParam {
+ public:
+  EraseRangeParam(TestShellCMD cmd, string lbaStart, string lbaEnd)
+      : IParam(cmd), lbaStart(lbaStart), lbaEnd(lbaEnd) {}
+  string lbaStart;
+  string lbaEnd;
 };
 
 class ScriptParam : public IParam {

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -97,6 +97,14 @@ class Parser {
         [&](const std::vector<std::string>& tokens) {
           return IsNumber(tokens[1]) && IsNumber(tokens[2]);
         }}},
+      {"erase_range",
+       {3, TestShellCMD::eEraseRangeCmd,
+        [&](const std::vector<std::string>& tokens) {
+          return new EraseRangeParam(TestShellCMD::eEraseRangeCmd, tokens[1], tokens[2]);
+        },
+        [&](const std::vector<std::string>& tokens) {
+          return IsNumber(tokens[1]) && IsNumber(tokens[2]);
+        }}},
       {"script",
        {1, TestShellCMD::eScriptCmd,
         [&](const std::vector<std::string>& tokens) {

--- a/Shell/RealSSD.cpp
+++ b/Shell/RealSSD.cpp
@@ -43,7 +43,19 @@ std::string RealSSD::Read(int lba) {
 }
 
 void RealSSD::Erase(int lba, int size) {
-  throw std::runtime_error("RealSSD::Erase() Not implemented");
+  if (IsInvalidLBA(lba)) {
+    return;
+  }
+
+  std::ostringstream cmd;
+  cmd << ssdExe << " E " << lba << " " << size;
+  execCommand(cmd.str());
+
+  std::ifstream in(outputFile);
+  std::string result;
+  if (!in.good() || !std::getline(in, result)) {
+    return;
+  }
 }
 
 void RealSSD::Flush() {

--- a/Shell/TestShell.cpp
+++ b/Shell/TestShell.cpp
@@ -64,6 +64,13 @@ int TestShell::parseAndExecCommand(std::string command) {
       commandErase.Call(program);
       break;
     }
+    case eEraseRangeCmd: {
+      EraseRangeParam* eraseRangeCmd =
+          dynamic_cast<EraseRangeParam*>(parsedCommand);
+      std::vector<std::string> program = {"erase_range", eraseRangeCmd->lbaStart, eraseRangeCmd->lbaEnd};
+      commandEraseRange.Call(program);
+      break;
+    }
     case eFlushCmd: {
       std::vector<std::string> program = {"flush"};
       commandFlush.Call(program);

--- a/Shell/TestShell.h
+++ b/Shell/TestShell.h
@@ -10,6 +10,7 @@
 #include "CmdExit.h"
 #include "CmdHelp.h"
 #include "CmdErase.h"
+#include "CmdEraseRange.h"
 #include "CmdFlush.h"
 #include "CmdTestScript.h"
 
@@ -33,6 +34,7 @@ class TestShell {
   CommandExit commandExit;
   CommandHelp commandHelp;
   CommandErase commandErase{&ssdDriver};
+  CommandEraseRange commandEraseRange{&ssdDriver};
   CommandFlush commandFlush{&ssdDriver};
   CommandTestScript commandTestScript{&ssdDriver};
 };


### PR DESCRIPTION
이 PR은 Erase와 관련된 두 가지 기능을 구현합니다.

- Shell에 구현되어 있던 EraseRange 커맨드를 Parser에서 파싱하여 TestShell에서 사용할 수 있도록 parser case 추가
  - 실제로 TestShell을 띄우면 `erase_range 5 3` (LBA 5부터 LBA 3까지 삭제) 와 같은 방법으로 EraseRange 명령어를 실행할 수 있습니다.
- #51 에서 추가된 SSD E 기능 (erase) 과 Shell의 Erase/EraseRange 연동
  - RealSSD를 통해서 TestShell을 띄우면 (디폴트 설정) 실제로 ssd.exe에게 `ssd.exe E 3 3` (LBA 3부터 3칸 삭제) 와 같은 방식으로 명령어를 전달하여 전체 integration이 이루어집니다.