### PR TITLE
[Bugfix] Add missing return value for SSD EraseCommand

### DIFF
--- a/SSD/EraseCommand.cpp
+++ b/SSD/EraseCommand.cpp
@@ -16,4 +16,5 @@ bool EraseCommand::Execute(IParam* param) {
     FD->SetBufferData(lba, 0);
   }
   FD->SaveFile(STORAGE_FILE_NAME, FD->GetBufferAddr(), MAX_STORAGE_IDX);
+  return true;
 }


### PR DESCRIPTION
이 PR은 기존 커밋에 미처 들어가지 못한 구현 한 줄을 추가합니다.

- SSD의 `EraseCommand::Execute()` 에서 성공 시 true를 리턴하도록 수정합니다.
  - 당장은 `Execute()` 리턴 값을 사용하지 않기 때문에 오류가 발생하는 상황은 아니었으나, 추후에 리턴 값을 사용하게 되는 경우 곧바로 오류가 발생할 여지가 있어 미리 수정합니다.